### PR TITLE
Add caching to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ script: "npm test"
 node_js:
   - "0.8"
   - "0.10"
+cache:
+  directories:
+    - node_modules
 notifications:
   irc:
     - "irc.freenode.org#bevry-dev"


### PR DESCRIPTION
Details from the following blog post:
  http://about.travis-ci.org/blog/2013-12-05-speed-up-your-builds-cache-your-dependencies/

Unfortunately currently only available for private repositories, but may be added to public ones sometime.
